### PR TITLE
Add default keyboard binding for todotxt-filter-out

### DIFF
--- a/todotxt.el
+++ b/todotxt.el
@@ -159,6 +159,7 @@ performed.  Defaults to 't."
 (define-key todotxt-mode-map (kbd "e") 'todotxt-edit-item)       ; (E)dit item
 (define-key todotxt-mode-map (kbd "t") 'todotxt-tag-item)        ; (T)ag item
 (define-key todotxt-mode-map (kbd "/") 'todotxt-filter-for)      ; 
+(define-key todotxt-mode-map (kbd "\\") 'todotxt-filter-out)     ; 
 (define-key todotxt-mode-map (kbd "s") 'save-buffer)             ; (S)ave
 (define-key todotxt-mode-map (kbd "n") 'next-line)               ; (N)ext
 (define-key todotxt-mode-map (kbd "p") 'previous-line)           ; (P)revious


### PR DESCRIPTION
todotxt-filter-out is a useful thing, and ought to have a keyboard
binding.  The one picked here, '\', is to emphasise that it's the
complement of todotxt-filter-for.
