### PR TITLE
Add todotxt-transpose-lines-(up|down)

### DIFF
--- a/todotxt-test.el
+++ b/todotxt-test.el
@@ -38,3 +38,182 @@
          (expected '("@context1" "@context2" "@context3" "+project1" "+project2")))
     (should (equal (sort (todotxt-get-tag-completion-list-from-string str) 'string>)
                    (sort expected 'string>)))))
+
+(ert-deftest todotxt-test-transpose-lines-up-at-top ()
+  (with-temp-buffer
+    (insert "abc
+def
+ghi
+")
+    (goto-char (point-min))
+    (todotxt-transpose-lines-up)
+    (should (equal "abc
+def
+ghi
+"
+                   (buffer-string)))
+    (should (equal nil (char-before)))
+    (should (equal ?a (char-after)))))
+
+(ert-deftest todotxt-test-transpose-lines-up-without-priority ()
+  (with-temp-buffer
+    (insert "abc
+def
+ghi
+")
+    (goto-char (point-min))
+    (forward-line)
+    (forward-char)
+    (todotxt-transpose-lines-up)
+    (should (equal "def
+abc
+ghi
+"
+                   (buffer-string)))
+    (should (equal nil (char-before)))
+    (should (equal ?d (char-after)))))
+
+(ert-deftest todotxt-test-transpose-lines-up-with-higher-priority ()
+  (with-temp-buffer
+    (insert "(A) abc
+def
+ghi
+")
+    (goto-char (point-min))
+    (forward-line)
+    (forward-char)
+    (todotxt-transpose-lines-up)
+    (should (equal "(A) abc
+def
+ghi
+"
+                   (buffer-string)))
+    (should (equal ?d (char-before)))
+    (should (equal ?e (char-after)))))
+
+(ert-deftest todotxt-test-transpose-lines-up-with-same-priority ()
+  (with-temp-buffer
+    (insert "(A) abc
+(A) def
+ghi
+")
+    (goto-char (point-min))
+    (forward-line)
+    (forward-char)
+    (todotxt-transpose-lines-up)
+    (should (equal "(A) def
+(A) abc
+ghi
+"
+                   (buffer-string)))
+    (should (equal nil (char-before)))
+    (should (equal ?\( (char-after)))))
+
+(ert-deftest todotxt-test-transpose-lines-up-in-filterd-buffer ()
+  (with-temp-buffer
+    (insert "abc +a
+def
+ghi +a
+")
+    (todotxt-filter (eval `(lambda () (not (todotxt-current-line-match "+a")))))
+    (todotxt-apply-active-filters)
+    (goto-char (point-min))
+    (forward-line)
+    (todotxt-transpose-lines-up)
+    (todotxt-unhide-all)
+    (should (equal "ghi +a
+abc +a
+def
+"
+                   (buffer-string)))
+    (should (equal nil (char-before)))
+    (should (equal ?g (char-after)))))
+
+(ert-deftest todotxt-test-transpose-lines-down-at-bottom ()
+  (with-temp-buffer
+    (insert "abc
+def
+ghi
+")
+    (goto-char (point-max))
+    (todotxt-transpose-lines-down)
+    (should (equal "abc
+def
+ghi
+"
+                   (buffer-string)))
+    (should (equal ?\C-j (char-before)))
+    (should (equal nil (char-after)))))
+
+(ert-deftest todotxt-test-transpose-lines-down-without-priority ()
+  (with-temp-buffer
+    (insert "abc
+def
+ghi
+")
+    (goto-char (point-min))
+    (forward-line)
+    (forward-char)
+    (todotxt-transpose-lines-down)
+    (should (equal "abc
+ghi
+def
+"
+                   (buffer-string)))
+    (should (equal ?\C-j (char-before)))
+    (should (equal ?d (char-after)))))
+
+(ert-deftest todotxt-test-transpose-lines-down-with-higher-priority ()
+  (with-temp-buffer
+    (insert "abc
+def
+(A) ghi
+")
+    (goto-char (point-min))
+    (forward-line)
+    (forward-char)
+    (todotxt-transpose-lines-down)
+    (should (equal "abc
+def
+(A) ghi
+"
+                   (buffer-string)))
+    (should (equal ?d (char-before)))
+    (should (equal ?e (char-after)))))
+
+(ert-deftest todotxt-test-transpose-lines-down-with-same-priority ()
+  (with-temp-buffer
+    (insert "abc
+(A) def
+(A) ghi
+")
+    (goto-char (point-min))
+    (forward-line)
+    (forward-char)
+    (todotxt-transpose-lines-down)
+    (should (equal "abc
+(A) ghi
+(A) def
+"
+                   (buffer-string)))
+    (should (equal ?\C-j (char-before)))
+    (should (equal ?\( (char-after)))))
+
+(ert-deftest todotxt-test-transpose-lines-down-in-filterd-buffer ()
+  (with-temp-buffer
+    (insert "abc +a
+def
+ghi +a
+")
+    (todotxt-filter (eval `(lambda () (not (todotxt-current-line-match "+a")))))
+    (todotxt-apply-active-filters)
+    (goto-char (point-min))
+    (todotxt-transpose-lines-down)
+    (todotxt-unhide-all)
+    (should (equal "def
+ghi +a
+abc +a
+"
+                   (buffer-string)))
+    (should (equal ?\C-j (char-before)))
+    (should (equal ?a (char-after)))))

--- a/todotxt.el
+++ b/todotxt.el
@@ -492,6 +492,42 @@ removed."
     (if todotxt-save-after-change (save-buffer))
     (setq inhibit-read-only nil)))
 
+(defun todotxt-transpose-lines (&optional backward)
+  (todotxt-find-next-visible-char)
+  (let* ((current-line-number (line-number-at-pos))
+         (current-line-string (todotxt-get-current-line-as-string))
+         (dest-line-number (save-excursion
+                             (line-move-visual (if backward -1 1) t)
+                             (todotxt-find-next-visible-char)
+                             (line-number-at-pos)))
+         (range (- dest-line-number current-line-number))
+         (dest-line-string (buffer-substring (point-at-bol (1+ range)) (point-at-eol (1+ range)))))
+    (when (and
+           (not (zerop range))
+           (not (equal current-line-string ""))
+           (not (equal dest-line-string ""))
+           (equal
+            (todotxt-sort-key-for-string current-line-string)
+            (todotxt-sort-key-for-string dest-line-string)))
+      (beginning-of-line)
+      (save-excursion
+        (remove-overlays)
+        (forward-line)
+        (setq inhibit-read-only t)
+        (transpose-lines range)
+        (setq inhibit-read-only nil)
+        (todotxt-apply-active-filters))
+      (todotxt-find-next-visible-char)
+      (forward-line (if backward -1 1)))))
+
+(defun todotxt-transpose-lines-up ()
+  (interactive)
+  (todotxt-transpose-lines t))
+
+(defun todotxt-transpose-lines-down ()
+  (interactive)
+  (todotxt-transpose-lines))
+
 (defun todotxt-archive-file-name ()
   (concat (file-name-directory todotxt-file) "/done.txt"))
 


### PR DESCRIPTION
This features are `transpose-lines` for todotxt.el. These can work between tasks which has same `sort-key`. These can work in filtered buffer too.