### PR TITLE
Bind 'h' to describe-mode

### DIFF
--- a/todotxt.el
+++ b/todotxt.el
@@ -298,6 +298,11 @@ or '+') and return a list of them."
 resides."
   (save-excursion
     (beginning-of-line)
+    "todotxt-find-nex-visible-char fixes a bug
+     but it is not compatible with some modes"
+    (unless (or (bound-and-true-p hl-line-mode)
+                (bound-and-true-p global-hl-line-mode))
+        (todotxt-find-next-visible-char))
     (let ((beg (point)))
       (end-of-line)
       (buffer-substring beg (point)))))


### PR DESCRIPTION
This PR adds one commit which binds 'h'.

(Sure '?' is already available but most modes also bind 'h' which is more comfortable, at least on some keyboard layouts.)