### PR TITLE
Fix todotxt-find-next-visible-char

### DIFF
--- a/todotxt.el
+++ b/todotxt.el
@@ -252,8 +252,10 @@ address an odd bug in which the point can exist at (point-min)
 even though it is invisible.  This usually needs to be called
 after items are filtered in some way, but perhaps in other case
 as well."
-  (while (invisible-p (point))
-    (forward-char)))
+  (let ((pos (point)))
+    (while (and (invisible-p pos) (< pos (point-max)))
+      (setq pos (1+ pos)))
+    (goto-char pos)))
 
 (defun todotxt-filter (predicate)
   "Hides lines for which the provided predicate returns 't.  This

--- a/todotxt.el
+++ b/todotxt.el
@@ -252,7 +252,7 @@ address an odd bug in which the point can exist at (point-min)
 even though it is invisible.  This usually needs to be called
 after items are filtered in some way, but perhaps in other case
 as well."
-  (while (not (equal (overlays-at (point)) nil))
+  (while (invisible-p (point))
     (forward-char)))
 
 (defun todotxt-filter (predicate)


### PR DESCRIPTION
Closes #29 

Changes `todotxt-find-next-visible-char` to skip only overlays marked 'invisible. Previous behaviour is that it doesn't work if a minor mode (like `hl-line-mode`) is adding overlays to the current line.

The first commit `(while (invisible-p (point)) (forward-char))` is simple and readable, the 2nd replaces it with a more performant one from stackexchange. Feel free to take either.