### PR TITLE
Fix moving point to added item

### DIFF
--- a/todotxt.el
+++ b/todotxt.el
@@ -241,8 +241,7 @@ Otherwise, return nil."
 beginning of the line containing that item."
   (todotxt-find-first-visible-char)
   (search-forward item)
-  (beginning-of-line)
-  (todotxt-find-first-visible-char))
+  (beginning-of-line))
 
 (defun todotxt-find-first-visible-char ()
   "Move the point to the first visible character in the buffer."


### PR DESCRIPTION
Calling todotxt-find-first-visible-char at this place again pretty much negates
the effects of the previous search, so remove this call.

This fixes not jumping to a newly added item.